### PR TITLE
Add missing `bluedevil` package

### DIFF
--- a/plasma
+++ b/plasma
@@ -1,5 +1,6 @@
 ark
 audiocd-kio
+bluedevil
 breeze-gtk
 dolphin
 dragon


### PR DESCRIPTION
Considering that the base install includes various packages for Bluetooth functionality. Plasma should have this package installed to make it available via System Settings (kcm) 

From the package description: 
`Integrate the Bluetooth technology within KDE workspace and applications.`